### PR TITLE
Add initial MCP2OpenAPI source generator and test project

### DIFF
--- a/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/Controllers/WeatherForecastController.cs
+++ b/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/Controllers/WeatherForecastController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace OA2MCP_TestMe.Controllers;
+
+//[Authorize]
+[ApiController]
+[Route("[controller]")]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    private readonly ILogger<WeatherForecastController> _logger;
+
+    public WeatherForecastController(ILogger<WeatherForecastController> logger)
+    {
+        _logger = logger;
+    }
+
+    [HttpGet(Name = "GetWeatherForecast")]
+    [EndpointDescription("Get weather forecast for the next 5 days")]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+        {
+            Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            TemperatureC = Random.Shared.Next(-20, 55),
+            Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+        })
+        .ToArray();
+    }
+}

--- a/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/OA2MCP_TestMe.csproj
+++ b/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/OA2MCP_TestMe.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+	  <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.4.1-preview.1" />
+    <PackageReference Include="NetCoreUsefullEndpoints" Version="9.2025.405.1013" />
+    <PackageReference Include="OpenAPISwaggerUI" Version="9.2024.1215.2209" />
+    <!-- <PackageReference Include="RSCG_OpenApi2MCP" Version="9.2025.410.706" OutputItemType="Analyzer"  /> -->
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RSCG_MCP2OpenAPI\RSCG_MCP2OpenAPI.csproj" OutputItemType="Analyzer"  />
+  </ItemGroup>
+
+  <PropertyGroup>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+		<CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GX</CompilerGeneratedFilesOutputPath>
+	</PropertyGroup>
+	<!-- from here -->
+	<ItemGroup>
+		<Watch Include=".\..\\RSCG_MCP2OpenAPI\Templates\*.cshtml" Exclude="node_modules\**\*;**\*.js.map;obj\**\*;bin\**\*" />
+	</ItemGroup>
+</Project>

--- a/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/OA2MCP_TestMe.http
+++ b/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/OA2MCP_TestMe.http
@@ -1,0 +1,6 @@
+@OA2MCP_TestMe_HostAddress = http://localhost:5246
+
+GET {{OA2MCP_TestMe_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/Program.cs
+++ b/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/Program.cs
@@ -1,0 +1,28 @@
+
+using Microsoft.AspNetCore.Mvc;
+using OA2MCP_TestMe;
+using OpenAPISwaggerUI;
+using UsefullExtensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+
+builder.Services.AddControllers();
+builder.Services.AddOpenApi();
+
+builder.Services.AddMcpServer()
+    .WithToolsFromAssembly()
+    .WithStdioServerTransport()
+    .WithHttpTransport()
+    ;
+
+
+var app = builder.Build();
+
+    app.MapOpenApi();
+    app.UseOpenAPISwaggerUI();
+    app.MapMcp();
+app.MapGet("/", () => "todo");
+app.MapControllers();
+
+await app.RunAsync();

--- a/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/Properties/launchSettings.json
+++ b/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/Properties/launchSettings.json
@@ -1,0 +1,25 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5246",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7187;http://localhost:5246",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/Tool1.cs
+++ b/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/Tool1.cs
@@ -1,0 +1,61 @@
+﻿namespace OA2MCP_TestMe;
+
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+[McpServerToolType]
+[MCP2OpenAPI.AddMCP2OpenApi]
+public partial class WeatherTool
+{
+    [McpServerTool, Description("echoes the UTC date time in sortable format")]
+    public string CurrentISODateTime()
+    {
+        return DateTime.UtcNow.ToString("s");
+    }
+    [McpServerTool, Description("echoes the string")]
+    public string EchoBack(string theString)
+    {
+        return theString;
+    }
+    [McpServerTool, Description("add 2 numbers")]
+    public string Add2Numbers(int x, int y)
+    {
+        return (x + y).ToString();
+    }
+        [McpServerTool, Description("Returns the current weather for a specific city")]
+    public string MyGetWeatherForCity(string cityName)
+    { 
+        Console.WriteLine("==========================");
+        Console.WriteLine($"Function Start WeatherTool: GetWeatherForCity called with cityName: {cityName}");
+
+        // generate a random weather report and return the result
+        var random = new Random();
+        var temperature = random.Next(-20, 40);
+        var condition = random.Next(0, 2) == 0 ? "Sunny" : "Rainy";
+        var humidity = random.Next(0, 100);
+        var windSpeed = random.Next(0, 20);
+        var report = $"Weather in {cityName}: {temperature}°C, {condition}, Humidity: {humidity}%, Wind Speed: {windSpeed} km/h";
+
+        Console.WriteLine("Function report: " + report);
+        Console.WriteLine($"Function End WeatherTool: GetWeatherForCity called with cityName: {cityName}");
+        Console.WriteLine("==========================");
+
+        return report;
+    }
+    //[ModelContextProtocol.Server.McpServerTool, System.ComponentModel.Description("TODO: desc from comments: ")]
+    //public static string MCP_api_usefull_date_start_Get()
+    //{
+    //    HttpClient httpClient = new HttpClient();
+    //    var url = "https://localhost/usefull_date/start";
+    //    var response = httpClient.GetAsync(url).Result;
+    //    if (response.IsSuccessStatusCode)
+    //    {
+    //        var result = response.Content.ReadAsStringAsync().Result;
+    //        return result;
+    //    }
+    //    else
+    //    {
+    //        throw new Exception($"Error: {response.StatusCode}");
+    //    }
+    //}
+
+}

--- a/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/WeatherForecast.cs
+++ b/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace OA2MCP_TestMe;
+
+public class WeatherForecast
+{
+    public DateOnly Date { get; set; }
+
+    public int TemperatureC { get; set; }
+
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}

--- a/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/appsettings.Development.json
+++ b/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/appsettings.json
+++ b/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/globals.cs
+++ b/src/RSCG_MCP2OpenAPI/OA2MCP_TestMe/globals.cs
@@ -1,0 +1,2 @@
+﻿//TODO: find the namespace  
+global using OA2MCP_TestMe;

--- a/src/RSCG_MCP2OpenAPI/README.md
+++ b/src/RSCG_MCP2OpenAPI/README.md
@@ -1,0 +1,18 @@
+# RSCG_MCP2File
+
+RSCG_MCP2File is a .NET Standard 2.0 source generator that generates MCP (Microsoft Code Platform) tools that generates exports to file from each MCP function defined 
+
+
+## Features
+- Generates tool from another 
+- 
+## Usage
+Add RSCG_MCP2File as a NuGet package to your project. 
+The generator will automatically run at build time and generate the necessary MCP tool code from tool definition.
+
+
+## License
+This project is licensed under the MIT License. 
+
+## Repository
+For more information, visit the [GitHub repository](https://github.com/ignatandrei/RSCG_OpenApi2MCP).

--- a/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI.slnx
+++ b/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="OA2MCP_TestMe/OA2MCP_TestMe.csproj" />
+  <Project Path="RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI.csproj" />
+</Solution>

--- a/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI/MCP2OpenAPI.cs
+++ b/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI/MCP2OpenAPI.cs
@@ -1,0 +1,76 @@
+﻿using RSCG_MCP2OpenAPI.Templates;
+
+namespace RSCG_MCP2OpenAPI;
+
+[Generator]
+public class MCP2OpenAPI : IIncrementalGenerator
+{
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        context
+          .RegisterPostInitializationOutput(i =>
+          {
+              i.AddEmbeddedAttributeDefinition();
+              i.AddSource("MCP2OpenAPI.g.cs", @"
+                namespace MCP2OpenAPI
+                {
+                    [global::Microsoft.CodeAnalysis.EmbeddedAttribute]
+                    [global::System.AttributeUsage(global::System.AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+                    internal class AddMCP2OpenApi: global::System.Attribute {} 
+                }");
+
+          });
+
+        var nr = 0;
+        var mcpClasses = context.SyntaxProvider.ForAttributeWithMetadataName(
+            "MCP2OpenAPI.AddMCP2OpenApi",
+            static (node, _) => node is ClassDeclarationSyntax,
+            static (context, _) =>
+            {
+                INamedTypeSymbol? classSymbol = null;
+                var classDeclaration = context.TargetNode as ClassDeclarationSyntax;
+                if (classDeclaration is null)
+                    return classSymbol;
+
+                classSymbol = context.TargetSymbol as INamedTypeSymbol;
+                return classSymbol;
+            })
+             .Where(static m => m is not null)
+            .Select(static (m, _) => m!)
+            .Collect()
+            ;
+        nr++;
+
+        context.RegisterSourceOutput(mcpClasses, (ctx, clsArr) =>
+        {
+            if (clsArr.Length == 0)
+                return;
+
+            foreach (var cls in clsArr)
+            {
+
+                var res = GenerateFromClass(cls);
+                if (res != null)
+                {
+                    ctx.AddSource($"{cls.Name}_ExportToFile.g.cs", res);
+
+                }
+            }
+
+        });
+    }
+
+    private string? GenerateFromClass(INamedTypeSymbol cls)
+    {
+
+        
+        var classInfo = new InfoFromClassSymbol(cls);
+        return classInfo.GenerateAPI();
+    }
+    static bool IsVoidOrTask(ITypeSymbol returnType)
+    {
+        return returnType.SpecialType == SpecialType.System_Void ||
+               returnType.ToDisplayString() == "System.Threading.Tasks.Task";
+    }
+
+}

--- a/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI.csproj
+++ b/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI.csproj
@@ -1,0 +1,81 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>12.0</LangVersion>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<IsRoslynComponent>true</IsRoslynComponent>
+		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<IsPackable>true</IsPackable>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+		<CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GX</CompilerGeneratedFilesOutputPath>
+	</PropertyGroup>
+	<ItemGroup>
+		<!-- Package the generator in the analyzer directory of the nuget package -->
+		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+	</ItemGroup>
+	<ItemGroup>
+
+
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"  />
+		<PackageReference Include="RazorBlade" Version="0.11.0" PrivateAssets="All" ExcludeAssets="compile;runtime" />
+		<None Include="../../../LICENSE" Pack="true" PackagePath="\" />
+		<None Include="../README.md" Pack="true" PackagePath="\" />
+		<None Include="../readme.txt">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+
+	</ItemGroup>
+	<ItemGroup>
+		<Watch Include="**\Templates\*.cshtml" Exclude="node_modules\**\*;**\*.js.map;obj\**\*;bin\**\*" />
+	</ItemGroup>
+	<PropertyGroup>
+		<Description>Generating MCP tool function that exports to file the result of another MCP tool.</Description>
+		<Copyright>MIT</Copyright>
+		<NeutralLanguage>en-US</NeutralLanguage>
+		<CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd))</CurrentDate>
+		<Authors>Andrei Ignat</Authors>
+		<Title>Generating MCP tool function that exports to file the result of another MCP tool</Title>
+		<PackageTags>dotnet;dotnetcore;csharp;generators;sourcegen;roslyn;mcp;</PackageTags>
+		<PackageProjectUrl>https://github.com/ignatandrei/RSCG_OpenApi2MCP</PackageProjectUrl>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<IncludeSymbols>true</IncludeSymbols>
+		<IncludeSource>true</IncludeSource>
+		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+		<WarningsNotAsErrors>CS0436,NU1903,CS0618,NU1900</WarningsNotAsErrors>
+		<NoWarn>NU5125;NU5039;CS0436;NU5128;NU1900</NoWarn>
+		<Version>9.2025.1202.1952</Version>
+		<RepositoryUrl>https://github.com/ignatandrei/RSCG_OpenApi2MCP</RepositoryUrl>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<RepositoryType>git</RepositoryType>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<IsPackable>true</IsPackable>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+		<SourceLinkCreate>true</SourceLinkCreate>
+		<SourceLinkOriginUrl>https://github.com/ignatandrei/RSCG_OpenApi2MCP</SourceLinkOriginUrl>
+	</PropertyGroup>
+
+
+
+</Project>

--- a/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI/Templates/Class2OpenAPI.cshtml
+++ b/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI/Templates/Class2OpenAPI.cshtml
@@ -1,0 +1,33 @@
+@inherits RazorBlade.PlainTextTemplate<InfoFromClassSymbol>
+@{
+    string nameSpace = "";
+    if (Model.Namespace?.Length > 0)
+    {
+        nameSpace = $"namespace {Model.Namespace};";
+    }
+}
+
+@nameSpace
+
+
+///Number methods : @Model.NrMethods
+partial class @(Model.ClassName)_OpenAPI
+{
+    public void AddAll(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder builder){
+        @foreach (var meth in Model.infoFromMethodSymbols)
+        {
+            string MethodName = $"Add_{meth.MethodName}(builder);\r\n";
+            @MethodName 
+
+
+        }
+    }
+
+@foreach (var meth in Model.infoFromMethodSymbols)
+{
+    var template = new Func2OpenAPI(meth);
+    @template.Render()
+}
+
+}
+

--- a/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI/Templates/Func2OpenAPI.cshtml
+++ b/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI/Templates/Func2OpenAPI.cshtml
@@ -1,0 +1,40 @@
+@inherits RazorBlade.PlainTextTemplate<InfoFromMethodSymbol>
+@{
+    string nameRecord = "rec_" + Model.MethodName;
+    bool IsStatic = Model.IsStatic;
+    string firstParam = IsStatic ? "":$"[Microsoft.AspNetCore.Mvc.FromServices]{Model.FullClassName} toolClass" ;
+    string allParams = "";
+    var argParams = Model.argParams;
+    if (firstParam.Length > 0 && Model.HasParams)
+    {
+        allParams = firstParam + "," + $"[Microsoft.AspNetCore.Mvc.FromBody]{nameRecord}  value"; ;
+    }
+    else if (firstParam.Length == 0 && Model.HasParams)
+    {
+        allParams = $"[Microsoft.AspNetCore.Mvc.FromBody]{nameRecord}  value";
+    }
+    else
+    {
+        allParams = firstParam + argParams;
+    }
+
+    string callData = IsStatic ? $"{Model.FullClassName}.":"toolClass.";
+    string argsToBeCalled = Model.HasParams ? $"({Model.callParamsRecord})" : "()";
+}
+
+@if(Model.HasParams){
+
+    <text>
+    public record @nameRecord ( @(argParams) );
+    </text>
+}
+
+public void Add_@(Model.MethodName) (Microsoft.AspNetCore.Routing.IEndpointRouteBuilder builder){
+    
+        builder.MapPost("/api/mcp/@Model.ClassName/@Model.MethodName",(@allParams)=>
+        @(callData+Model.MethodName + argsToBeCalled)
+        );
+
+}
+
+

--- a/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI/Templates/InfoFromClassSymbol.cs
+++ b/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI/Templates/InfoFromClassSymbol.cs
@@ -1,0 +1,36 @@
+﻿namespace RSCG_MCP2OpenAPI.Templates;
+
+public class InfoFromClassSymbol
+{
+    public string? Namespace { get; private set; }
+    public string FullClassName { get; private set; }
+    public string ClassName { get; private set; }
+
+    public InfoFromMethodSymbol[] infoFromMethodSymbols { get; private set; }
+    public InfoFromClassSymbol(INamedTypeSymbol classParent)
+    {
+        ClassName = classParent.Name;
+        FullClassName = classParent.Name;
+        if(classParent.ContainingNamespace != null && !classParent.ContainingNamespace.IsGlobalNamespace)
+        {
+            Namespace = classParent.ContainingNamespace.ToDisplayString();
+            FullClassName = Namespace + "." + FullClassName;
+        }
+        infoFromMethodSymbols = classParent
+           .GetMembers()
+           .OfType<IMethodSymbol>()
+           .Where(m =>
+               m.GetAttributes().Any(a => a.AttributeClass != null && a.AttributeClass.ToDisplayString().Contains("McpServerTool")) &&
+               m.MethodKind == MethodKind.Ordinary
+               )
+           .Select(it=>new InfoFromMethodSymbol(it,this))
+           .ToArray();
+    }
+    public int NrMethods => infoFromMethodSymbols?.Length ??0;
+
+    internal string? GenerateAPI()
+    {
+        Class2OpenAPI class2OpenAPI = new Class2OpenAPI(this);
+        return class2OpenAPI.Render();
+    }
+}

--- a/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI/Templates/InfoFromMethodSymbol.cs
+++ b/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI/Templates/InfoFromMethodSymbol.cs
@@ -1,0 +1,48 @@
+﻿
+using Microsoft.CodeAnalysis;
+
+namespace RSCG_MCP2OpenAPI.Templates;
+    public class InfoFromMethodSymbol
+{
+
+    public InfoFromMethodSymbol(IMethodSymbol methodSymbol, InfoFromClassSymbol classParent)
+    {
+
+
+        ClassName = classParent.ClassName;
+        FullClassName = classParent.FullClassName;
+
+        if (classParent.Namespace != null) {
+            Namespace = classParent.Namespace;
+        }
+
+        IsStatic = methodSymbol.IsStatic;
+        MethodName = methodSymbol.Name;
+        var methodParams = methodSymbol.Parameters;
+        //switch (methodParams.Length)
+        //{
+        //    case 0:
+        //        ShouldBeGet = true;
+        //        break;
+        //    default:
+        //        ShouldBeGet = false;
+        //        break;
+        //}
+        
+        argParams = string.Join(", ",methodParams.Select(it=>it.Type.ToDisplayString(NullableFlowState.MaybeNull) +" "+ it.Name)); 
+        callParamsRecord = string.Join(", ", methodParams.Select(it => "value."+it.Name));
+        HasParams = methodParams.Length> 0;
+        
+    }
+
+    public bool HasParams { get; private set; }
+    public string argParams { get; private set; }
+    public string callParamsRecord { get; private set; }
+    //public bool ShouldBeGet { get; private set; }
+    public bool IsStatic { get;private set; }
+
+    public string? Namespace {  get; private set; }
+    public string FullClassName { get; private set;  }
+    public string ClassName { get; private set; }
+    public string MethodName { get; private set;  }
+}

--- a/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI/globals.cs
+++ b/src/RSCG_MCP2OpenAPI/RSCG_MCP2OpenAPI/globals.cs
@@ -1,0 +1,3 @@
+﻿global using Microsoft.CodeAnalysis;
+global using Microsoft.CodeAnalysis.CSharp.Syntax;
+global using RSCG_MCP2OpenAPI.Templates;

--- a/src/RSCG_MCP2OpenAPI/global.json
+++ b/src/RSCG_MCP2OpenAPI/global.json
@@ -1,0 +1,9 @@
+{
+  "scripts": {
+    "build": "dotnet build --configuration Release",
+    "test": "dotnet test --configuration Release",
+    "ci": "dotnet r build",    
+    "pack":"dotnet pack -o ../nugetPackages"
+
+  }
+}

--- a/src/RSCG_MCP2OpenAPI/readme.txt
+++ b/src/RSCG_MCP2OpenAPI/readme.txt
@@ -1,0 +1,22 @@
+# RSCG_MCP2File
+
+RSCG_MCP2File is a .NET Standard 2.0 source generator that generates MCP (Microsoft Code Platform) tools that generates exports to file from each MCP function defined 
+
+
+## Features
+- Generates code from Swagger (OpenAPI) definitions during build
+- Integrates with the .NET build process
+- Designed for use in MCP tool generation scenarios
+- Supports .NET Standard 2.0 for broad compatibility
+
+## Usage
+Add RSCG_MCP2File as a NuGet package to your project. The generator will automatically run at build time and generate the necessary MCP tool code from your Swagger definitions.
+
+## Build
+This project is configured to emit compiler-generated files to the `GX` directory under the intermediate output path. It uses Roslyn and is compatible with CI/CD environments.
+
+## License
+This project is licensed under the MIT License. 
+
+## Repository
+For more information, visit the [GitHub repository](https://github.com/ignatandrei/RSCG_OpenApi2MCP).


### PR DESCRIPTION
Introduces the RSCG_MCP2OpenAPI source generator for MCP tool code generation, including templates and supporting files. Adds OA2MCP_TestMe ASP.NET Core test project with sample WeatherForecast controller, tool class, and configuration for demonstrating MCP/OpenAPI integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a test application demonstrating OpenAPI-based weather service with MCP-exposed tools for retrieving weather by city, echoing text, performing number calculations, and obtaining current UTC time in ISO format.
  * Introduced a weather forecast API endpoint providing 5-day forecasts with random temperatures and conditions.

* **Documentation**
  * Added project README and configuration guide.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->